### PR TITLE
singular and plural names based on number of endpoints

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ const wireEndpoint = (router, endpoint, resourceName) => {
 }
 
 const wireResource = (router) => (endpoints, resourceName) => {
-  debug(`Loaded ${endpoints.length} endpoints for "${resourceName}"`)
+  const number = endpoints.length > 1 ? 'endpoints' : 'endpoint'
+  debug(`Loaded ${endpoints.length} ${number} for "${resourceName}"`)
   each(endpoints, (endpoint) =>
     wireEndpoint(router, endpoint, resourceName)
   )


### PR DESCRIPTION
This allows the output to respond based on the number of endpoints:

```
 sutro:loader Loaded 1 endpoint for "network"
 sutro:loader   - find (GET /networks)
 sutro:loader Loaded 5 endpoints for "user"
 sutro:loader   - search (GET /users/search)
 sutro:loader   - create (POST /users)
...

```