### PR TITLE
Fix bug when the handlerFn returns false or null

### DIFF
--- a/src/handleAsync.js
+++ b/src/handleAsync.js
@@ -17,7 +17,7 @@ const handleAsync = (fn, cb) => {
   }
 
   // using a callback, itll call with a response
-  if (typeof res === 'undefined') return
+  if (!res || typeof res === 'undefined') return
 
   // using a promise
   if (typeof res.then === 'function') {


### PR DESCRIPTION
- The handler fn check only looks for `undefined` when express middleware can return false or null.

```stack
curl 'http://localhost:3000/v1/REDACTED' -H 'Origin: http://localhost:3000' -H 'Accept-Encoding: gzip, def$
ate, br' -H 'Accept-Language: en-US,en;q=0.8' --data-binary '{"name":"test","type":"admin"}' --compressed
{"type":"unknown","status":500,"error":"TypeError: Cannot read property 'then' of null\n   
 at handleAsync (/node_modules/sutro/dist/handleAsync.js:34:17)\n 

```