### PR TITLE
add type:"string" to swagger parameters to pass validation

### DIFF
--- a/src/getSwagger.js
+++ b/src/getSwagger.js
@@ -48,7 +48,8 @@ const getPaths = (resources) => {
       parameters: params && params.map((name) => ({
         name: name.slice(1),
         in: 'path',
-        required: true
+        required: true,
+        type: 'string'
       })) || undefined,
       responses: getResponses(method, endpoint),
       ...swaggerMeta


### PR DESCRIPTION
This allows the generated swagger config to pass the validator: http://editor.swagger.io